### PR TITLE
#7 BUGFIX - 자료형오류

### DIFF
--- a/src/main/java/com/hana/sugang/api/course/service/CourseService.java
+++ b/src/main/java/com/hana/sugang/api/course/service/CourseService.java
@@ -1,0 +1,16 @@
+package com.hana.sugang.api.course.service;
+
+import com.hana.sugang.api.course.repository.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+
+
+}


### PR DESCRIPTION
CourseEntity에 courseType 필드의 자료형을, CascadeType에서 CourseType으로 변경하였다.