### PR TITLE
#29 RESTAPI를 더 탄탄하게 만들기

### DIFF
--- a/src/main/java/com/hana/sugang/api/course/controller/CourseController.java
+++ b/src/main/java/com/hana/sugang/api/course/controller/CourseController.java
@@ -2,6 +2,7 @@ package com.hana.sugang.api.course.controller;
 
 import com.hana.sugang.api.course.dto.request.CourseApply;
 import com.hana.sugang.api.course.dto.request.CourseCreate;
+import com.hana.sugang.api.course.dto.request.CourseEdit;
 import com.hana.sugang.api.course.dto.request.CourseSearch;
 import com.hana.sugang.api.course.dto.response.CourseResponse;
 import com.hana.sugang.api.course.service.CourseService;
@@ -34,7 +35,22 @@ public class CourseController {
 
         map.put("id",id);
         return map;
+    }
+    @PatchMapping("/course/{id}")
+    public Map<String, Long> editCourse(@PathVariable(name = "id") Long id, @RequestBody @Validated CourseEdit requestDto) {
+        Map<String, Long> map = new HashMap<>();
+        Long courseId = courseService.editCourse(id, requestDto);
 
+        map.put("id",courseId);
+        return map;
+    }
+    @DeleteMapping("/course/{id}")
+    public Map<String, Long> deleteCourse(@PathVariable(name = "id") Long id) {
+        Map<String, Long> map = new HashMap<>();
+        courseService.deleteCourse(id);
+
+        map.put("id",id);
+        return map;
     }
 
     /**

--- a/src/main/java/com/hana/sugang/api/course/domain/Course.java
+++ b/src/main/java/com/hana/sugang/api/course/domain/Course.java
@@ -4,6 +4,7 @@ package com.hana.sugang.api.course.domain;
 import com.hana.sugang.api.course.domain.constant.CourseType;
 import com.hana.sugang.api.course.domain.constant.CourseTypeConverter;
 import com.hana.sugang.api.course.domain.mapping.MemberCourse;
+import com.hana.sugang.api.course.dto.request.CourseEdit;
 import com.hana.sugang.global.domain.AuditingFields;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,9 +13,12 @@ import org.hibernate.annotations.ColumnDefault;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.springframework.util.StringUtils.hasText;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Course extends AuditingFields {
 
     @Id
@@ -89,5 +93,28 @@ public class Course extends AuditingFields {
         this.currentCount = this.maxCount;
     }
 
-
+    /**
+     * 상태변경 메소드
+     * 필드값이 null이면 기본값 유지, 그렇지않으면 변경
+     * @param requestDto
+     */
+    // TODO 빈값 체크를 위해 if문이 계속 붙어있다.
+    //  더 세련되게 처리할 수있을 것 같은데 생각이 잘 안남..
+    public void edit(CourseEdit requestDto) {
+        if (hasText(requestDto.title())) {
+            this.title = requestDto.title();
+        }
+        if (hasText(requestDto.description())) {
+            this.description = requestDto.description();
+        }
+        if (requestDto.maxCount() != null) {
+            this.maxCount = requestDto.maxCount();
+        }
+        if (requestDto.courseType() != null) {
+            this.courseType = requestDto.courseType();
+        }
+        if (requestDto.score() != null) {
+            this.score = requestDto.score();
+        }
+    }
 }

--- a/src/main/java/com/hana/sugang/api/course/domain/Course.java
+++ b/src/main/java/com/hana/sugang/api/course/domain/Course.java
@@ -18,17 +18,13 @@ import static org.springframework.util.StringUtils.hasText;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
 public class Course extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-
     @Column(nullable = false, length = 50)
     private String code; // 교과목 코드
-
     @Column(nullable = false, length = 50)
     private String title; // 과목명
     @Column(length = 500)
@@ -37,15 +33,10 @@ public class Course extends AuditingFields {
     private Integer maxCount; // 최대 수강신청가능 인원 수
     @ColumnDefault("0")
     private Integer currentCount;// 현재 수강신청 인원 수
-
-
     @Convert(converter = CourseTypeConverter.class)
     @Column(nullable = false, length = 10)
     private CourseType courseType; //교양, 전공여부
-
     private Integer score; // 학점
-
-
     @OneToMany(mappedBy = "course", cascade = {CascadeType.ALL})
     private List<MemberCourse> memberCourses = new ArrayList<>();
 

--- a/src/main/java/com/hana/sugang/api/course/domain/mapping/MemberCourse.java
+++ b/src/main/java/com/hana/sugang/api/course/domain/mapping/MemberCourse.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-
+@Getter
 @Table(uniqueConstraints={
         // 두 필드가 동시에 같은 경우는 없음
         @UniqueConstraint(columnNames = {"course_id", "member_id"})
@@ -18,7 +18,6 @@ public class MemberCourse {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Getter
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/hana/sugang/api/course/domain/mapping/MemberCourse.java
+++ b/src/main/java/com/hana/sugang/api/course/domain/mapping/MemberCourse.java
@@ -1,5 +1,6 @@
 package com.hana.sugang.api.course.domain.mapping;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hana.sugang.api.course.domain.Course;
 import com.hana.sugang.api.member.domain.Member;
 import jakarta.persistence.*;
@@ -22,14 +23,25 @@ public class MemberCourse {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id")
+    @JsonIgnore
     private Course course; // 강의 Id
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @JsonIgnore
     private Member member; // 회원Id
 
 
     public static MemberCourse of(Course course, Member member) {
-        return new MemberCourse(course, member);
+        MemberCourse memberCourse = new MemberCourse(course, member);
+
+        /**
+         * 연관관계 매핑
+         */
+        course.getMemberCourses().add(memberCourse);
+        member.getMemberCourses().add(memberCourse);
+
+        return memberCourse;
+
     }
 
     public MemberCourse(Course course, Member member) {

--- a/src/main/java/com/hana/sugang/api/course/dto/request/CourseEdit.java
+++ b/src/main/java/com/hana/sugang/api/course/dto/request/CourseEdit.java
@@ -1,0 +1,39 @@
+package com.hana.sugang.api.course.dto.request;
+
+import com.hana.sugang.api.course.domain.Course;
+import com.hana.sugang.api.course.domain.constant.CourseType;
+import com.hana.sugang.global.valid.ValidEnum;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 강의 수정 Dto 객체
+ */
+public record CourseEdit(
+
+        @NotBlank(message = "강의명을 입력해주세요.")
+        String title, // 강의명
+        String description, // 강의설명
+        @Max(value = 100,message = "수강인원은 100명을 넘을 수 없습니다.")
+        Integer maxCount, // 최대 수강가능 인원 수
+        @ValidEnum(enumClass = CourseType.class, message = "전공, 교양 여부를 선택해주세요.")
+        CourseType courseType, //전공, 교양 여부
+        @Min(value = 1, message = "학점은 1 보다 낮을 수 없습니다.")
+        @Max(value = 3, message = "학점은 3보다 높을 수 없습니다.")
+        Integer score
+) {
+
+    public static CourseEdit of(String title, String description, Integer maxCount, CourseType courseType, Integer score) {
+        return new CourseEdit(title, description, maxCount, courseType, score);
+    }
+    public static Course toEntity(CourseEdit requestDto) {
+        return Course.builder()
+                .title(requestDto.title)
+                .description(requestDto.description)
+                .maxCount(requestDto.maxCount)
+                .courseType(requestDto.courseType)
+                .score(requestDto.score)
+                .build();
+    }
+}

--- a/src/main/java/com/hana/sugang/api/course/repository/CourseRepositoryCustom.java
+++ b/src/main/java/com/hana/sugang/api/course/repository/CourseRepositoryCustom.java
@@ -10,4 +10,7 @@ public interface CourseRepositoryCustom {
     List<Course> getList(CourseSearch courseSearch);
 
     Optional<Course> findBYIdWithQuery(Long id);
+
+    Optional<Course> getCourseWithFetchJoin(Long id);
+
 }

--- a/src/main/java/com/hana/sugang/api/course/repository/CourseRepositoryImpl.java
+++ b/src/main/java/com/hana/sugang/api/course/repository/CourseRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.hana.sugang.api.course.repository;
 
 import com.hana.sugang.api.course.domain.Course;
+import com.hana.sugang.api.course.domain.mapping.QMemberCourse;
 import com.hana.sugang.api.course.dto.request.CourseSearch;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
@@ -10,6 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.hana.sugang.api.course.domain.QCourse.course;
+import static com.hana.sugang.api.course.domain.mapping.QMemberCourse.memberCourse;
+import static com.hana.sugang.api.member.domain.QMember.member;
 
 @RequiredArgsConstructor
 public class CourseRepositoryImpl implements CourseRepositoryCustom {
@@ -37,4 +40,14 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
                 .fetchOne());
 
     }
+
+    @Override
+    public Optional<Course> getCourseWithFetchJoin(Long id) {
+        return Optional.ofNullable(queryFactory.selectFrom(course)
+                .leftJoin(course.memberCourses, memberCourse).fetchJoin()
+                .leftJoin(memberCourse.member, member).fetchJoin()
+                .where(course.id.eq(id))
+                .fetchOne());
+    }
+
 }

--- a/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepository.java
+++ b/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepository.java
@@ -1,11 +1,15 @@
 package com.hana.sugang.api.course.repository.mapping;
 
+import com.hana.sugang.api.course.domain.Course;
 import com.hana.sugang.api.course.domain.mapping.MemberCourse;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberCourseRepository extends JpaRepository<MemberCourse, Long> {
+public interface MemberCourseRepository extends JpaRepository<MemberCourse, Long>,MemberCourseRepositoryCustom {
 
-    public Optional<MemberCourse> findMemberCourseByMemberIdAndCourseId(Long memberId, Long courseId);
+    Optional<MemberCourse> findMemberCourseByMemberIdAndCourseId(Long memberId, Long courseId);
+
+    void deleteByCourse(Course course);
+
 }

--- a/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryCustom.java
+++ b/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.hana.sugang.api.course.repository.mapping;
+
+import com.hana.sugang.api.course.domain.Course;
+import com.hana.sugang.api.course.domain.mapping.MemberCourse;
+
+import java.util.List;
+
+public interface MemberCourseRepositoryCustom {
+
+    List<MemberCourse> findAllByCourse(Course course);
+}

--- a/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryCustom.java
+++ b/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface MemberCourseRepositoryCustom {
 
-    List<MemberCourse> findAllByCourse(Course course);
+    void deleteAllByCourse (Course course);
 }

--- a/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryImpl.java
+++ b/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.hana.sugang.api.course.repository.mapping;
+
+import com.hana.sugang.api.course.domain.Course;
+import com.hana.sugang.api.course.domain.mapping.MemberCourse;
+import com.hana.sugang.api.course.domain.mapping.QMemberCourse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.hana.sugang.api.course.domain.mapping.QMemberCourse.memberCourse;
+
+@RequiredArgsConstructor
+public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<MemberCourse> findAllByCourse(Course course) {
+        return queryFactory.select(memberCourse)
+                .from(memberCourse)
+                .where(memberCourse.course.eq(course))
+                .fetch();
+    }
+}

--- a/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryImpl.java
+++ b/src/main/java/com/hana/sugang/api/course/repository/mapping/MemberCourseRepositoryImpl.java
@@ -1,12 +1,8 @@
 package com.hana.sugang.api.course.repository.mapping;
 
 import com.hana.sugang.api.course.domain.Course;
-import com.hana.sugang.api.course.domain.mapping.MemberCourse;
-import com.hana.sugang.api.course.domain.mapping.QMemberCourse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 import static com.hana.sugang.api.course.domain.mapping.QMemberCourse.memberCourse;
 
@@ -15,12 +11,8 @@ public class MemberCourseRepositoryImpl implements MemberCourseRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
 
-
     @Override
-    public List<MemberCourse> findAllByCourse(Course course) {
-        return queryFactory.select(memberCourse)
-                .from(memberCourse)
-                .where(memberCourse.course.eq(course))
-                .fetch();
+    public void deleteAllByCourse(Course course) {
+        queryFactory.delete(memberCourse).where(memberCourse.course.eq(course)).execute();
     }
 }

--- a/src/main/java/com/hana/sugang/api/course/service/CourseService.java
+++ b/src/main/java/com/hana/sugang/api/course/service/CourseService.java
@@ -4,6 +4,7 @@ import com.hana.sugang.api.course.domain.Course;
 import com.hana.sugang.api.course.domain.mapping.MemberCourse;
 import com.hana.sugang.api.course.dto.request.CourseApply;
 import com.hana.sugang.api.course.dto.request.CourseCreate;
+import com.hana.sugang.api.course.dto.request.CourseEdit;
 import com.hana.sugang.api.course.dto.request.CourseSearch;
 import com.hana.sugang.api.course.dto.response.CourseResponse;
 import com.hana.sugang.api.course.repository.CourseRepository;
@@ -89,5 +90,46 @@ public class CourseService {
     }
 
 
+    /**
+     * 강의정보 수정 method
+     * @param id
+     * @param requestDto
+     * @return id
+     */
+    @Transactional
+    public Long editCourse(Long id, CourseEdit requestDto) {
+        Course course = courseRepository.findById(id).orElseThrow(CourseNotFoundException::new);
 
+        course.edit(requestDto);
+
+        return course.getId();
+    }
+
+    /**
+     * 강의정보 삭제 method
+     * @param id
+     */
+    //TODO 연관관계 생각.
+    // 강의만 지우면 안되고 연관된 학생정보도 수정이 되어야함
+    // TODO N+1 터짐. 이거 fetchJoin으로 해결가능
+    @Transactional
+    public void deleteCourse(Long id) {
+        System.out.println("[CourseService] - called");
+        Course course = courseRepository.findById(id).orElseThrow(CourseNotFoundException::new);
+        courseRepository.deleteById(id);
+
+        List<MemberCourse> memberCourses = memberCourseRepository.findAllByCourse(course);
+
+        memberCourses.forEach(e -> {
+            Member member = memberRepository.findById(e.getMember().getId()).orElseThrow(MemberNotFoundException::new);
+            memberCourseRepository.deleteById(e.getId());
+            member.decreaseCurrentScore(course.getScore());
+        });
+
+
+
+        System.out.println("[CourseService] - end");
+
+
+    }
 }

--- a/src/main/java/com/hana/sugang/api/member/domain/Member.java
+++ b/src/main/java/com/hana/sugang/api/member/domain/Member.java
@@ -15,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@ToString
 public class Member  extends AuditingFields {
 
     @Id
@@ -83,6 +84,16 @@ public class Member  extends AuditingFields {
      */
     public void addCurrentScore(Integer score) {
         this.currentScore += score;
+    }
+
+
+    /**
+     * 수강취소 혹은 강의 삭제시
+     * 해당 강의의 학점만큼 신청한 학점 감소
+     * @param score
+     */
+    public void decreaseCurrentScore(Integer score) {
+        this.currentScore -= score;
     }
     
     

--- a/src/main/java/com/hana/sugang/api/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/hana/sugang/api/member/repository/MemberRepositoryCustom.java
@@ -3,7 +3,10 @@ package com.hana.sugang.api.member.repository;
 import com.hana.sugang.api.member.domain.Member;
 
 import java.util.Optional;
+import java.util.Set;
 
 public interface MemberRepositoryCustom {
     Optional<Member> findBYUsernameWithQuery(String username);
+
+    void decreaseCurrentScore(Set<Long> Ids, Integer score);
 }

--- a/src/main/java/com/hana/sugang/api/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/hana/sugang/api/member/repository/MemberRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.hana.sugang.api.member.repository;
 
 import com.hana.sugang.api.member.domain.Member;
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.hana.sugang.api.member.domain.QMember.member;
 
@@ -21,5 +25,16 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
                 .where(member.username.eq(username))
                 .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                 .fetchOne());
+    }
+
+    public void decreaseCurrentScore(Set<Long> ids, Integer score) {
+        NumberTemplate<Integer> subtractedScore = Expressions.numberTemplate(
+                Integer.class, "{0} - {1}",
+                member.currentScore,
+                ConstantImpl.create(score));
+
+        queryFactory.update(member)
+                .set(member.currentScore, subtractedScore)
+                .where(member.id.in(ids)).execute();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
       ddl-auto: update
     show-sql: true
     open-in-view: false
+    properties:
+      hibernate:
+        default_batch_fetch_size: 200
   datasource:
     url: ${MYSQL_URL}
     username: ${MYSQL_USERNAME}

--- a/src/test/java/com/hana/sugang/api/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/hana/sugang/api/course/controller/CourseControllerTest.java
@@ -3,18 +3,20 @@ package com.hana.sugang.api.course.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hana.sugang.api.course.domain.Course;
 import com.hana.sugang.api.course.domain.constant.CourseType;
+import com.hana.sugang.api.course.domain.mapping.MemberCourse;
 import com.hana.sugang.api.course.dto.request.CourseApply;
 import com.hana.sugang.api.course.dto.request.CourseCreate;
+import com.hana.sugang.api.course.dto.request.CourseEdit;
 import com.hana.sugang.api.course.repository.CourseRepository;
 import com.hana.sugang.api.course.repository.mapping.MemberCourseRepository;
+import com.hana.sugang.api.course.service.CourseService;
 import com.hana.sugang.api.member.domain.Member;
 import com.hana.sugang.api.member.domain.constant.MemberType;
 import com.hana.sugang.api.member.repository.MemberRepository;
+import com.hana.sugang.global.exception.CourseNotFoundException;
+import jakarta.persistence.EntityManager;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,6 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -29,8 +32,7 @@ import java.util.regex.Matcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,6 +53,8 @@ class CourseControllerTest {
     private MemberRepository memberRepository;
     @Autowired
     private MemberCourseRepository memberCourseRepository;
+    @Autowired
+    private EntityManager em;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -311,6 +315,143 @@ class CourseControllerTest {
 
     }
 
+    @Test
+    @DisplayName("강의정보 수정 성공케이스")
+    void editCourse() throws Exception {
+        //given
+        CourseCreate createCourse = CourseCreate.of("ZZZZ01","테스트등록강의","설명입니다.",30, CourseType.CC,3 );
+        Course savedCourse = courseRepository.save(CourseCreate.toEntity(createCourse));
+
+        CourseEdit editCourse = CourseEdit.of("ZZZZ02", "테스트강의수정", 33, CourseType.GC, 2);
+        String json = objectMapper.writeValueAsString(editCourse);
+
+        //when & then
+        mvc.perform(patch("/course/"+savedCourse.getId())
+                        .contentType(APPLICATION_JSON)
+                        .content(json)
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        Course resultCourse = courseRepository.findById(savedCourse.getId()).orElseThrow(ClassNotFoundException::new);
+        assertThat(resultCourse.getTitle()).isEqualTo("ZZZZ02");
+        assertThat(resultCourse.getDescription()).isEqualTo("테스트강의수정");
+        assertThat(resultCourse.getMaxCount()).isEqualTo(33);
+        assertThat(resultCourse.getCourseType()).isEqualTo(CourseType.GC);
+        assertThat(resultCourse.getScore()).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("강의정보 수정시 교양/전공 여부는 필수이다.")
+    void editCourseWithNoCourseType() throws Exception {
+        //given
+        CourseCreate createCourse = CourseCreate.of("ZZZZ01","테스트등록강의","설명입니다.",30, CourseType.CC,3 );
+        Course savedCourse = courseRepository.save(CourseCreate.toEntity(createCourse));
+
+        CourseEdit editCourse = CourseEdit.of("ZZZZ02", "테스트강의수정", 33, null, 2);
+        String json = objectMapper.writeValueAsString(editCourse);
+
+        //when & then
+        mvc.perform(patch("/course/"+savedCourse.getId())
+                        .contentType(APPLICATION_JSON)
+                        .content(json)
+                )
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.validation.courseType").value("전공, 교양 여부를 선택해주세요."))
+                .andDo(print());
+    }
+
+    
+    @Test
+    @DisplayName("강의삭제 성공케이스")
+    @Transactional
+    void deleteCourse() throws Exception {
+        //given
+        CourseCreate createCourse = CourseCreate.of("ZZZZ01","테스트등록강의","설명입니다.",30, CourseType.CC,3 );
+        Course savedCourse = courseRepository.save(CourseCreate.toEntity(createCourse));
+        long before = courseRepository.count();
+
+        //when & then
+        mvc.perform(delete("/course/"+savedCourse.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andDo(print());
+
+        long after = courseRepository.count();
+        assertThat(after).isEqualTo(before-1);
+
+        // 삭제한 강의로 조회시 예외발생
+        assertThrows(CourseNotFoundException.class, () -> {
+            courseRepository.findById(savedCourse.getId()).orElseThrow(CourseNotFoundException::new);
+        });
+    }
+
+    @Test
+    @DisplayName("강의삭제- 존재하지 않는강의 삭제시 아무일도 일어나지 않는다.")
+    @Transactional
+    void deleteCourseWithNoId() throws Exception {
+        //given
+        //Nothing
+
+        //when & then
+        mvc.perform(delete("/course/"+9999999))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("강의 삭제시 수강신청이 된 학생이 있는 경우.")
+    //TODO 서비스코드테스트 우선 작성 후 이후 상황에 맞추어 정리하기
+    void deleteCourseWithApplyStudent() throws Exception {
+        //given
+        CourseCreate createCourse = CourseCreate.of("ZZZZ01","테스트등록강의","설명입니다.",30, CourseType.CC,3 );
+        Course course = CourseCreate.toEntity(createCourse);
+        Member member = createMember();
+
+        //수강신청 로직 수행
+        courseRepository.save(course);
+        memberRepository.save(member);
+        course.addCurrentCount();
+        member.addCurrentScore(course.getScore());
+        em.flush();
+
+        MemberCourse memberCourse = MemberCourse.of(course, member);
+        memberCourseRepository.save(memberCourse);
+
+        System.out.println("여기!!");
+        System.out.println(member.toString());
+        System.out.println(course.toString());
+        System.out.println(memberCourseRepository.count());
+        System.out.println("여기!!");
+
+
+        long before = courseRepository.count();
+
+        //when & then
+        mvc.perform(delete("/course/"+course.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andDo(print());
+
+
+        System.out.println("여기!!");
+        System.out.println(member.toString());
+        System.out.println(course.toString());
+        System.out.println(memberCourseRepository.count());
+        System.out.println("여기!!");
+
+
+        long after = courseRepository.count();
+        assertThat(after).isEqualTo(before-1);
+
+        // 삭제한 강의로 조회시 예외발생
+//        assertThrows(CourseNotFoundException.class, () -> {
+//            courseRepository.findById(course.getId()).orElseThrow(CourseNotFoundException::new);
+//        });
+    }
 
 
     @Test

--- a/src/test/java/com/hana/sugang/api/course/service/CourseServiceTest.java
+++ b/src/test/java/com/hana/sugang/api/course/service/CourseServiceTest.java
@@ -2,8 +2,10 @@ package com.hana.sugang.api.course.service;
 
 import com.hana.sugang.api.course.domain.Course;
 import com.hana.sugang.api.course.domain.constant.CourseType;
+import com.hana.sugang.api.course.domain.mapping.MemberCourse;
 import com.hana.sugang.api.course.dto.request.CourseApply;
 import com.hana.sugang.api.course.dto.request.CourseCreate;
+import com.hana.sugang.api.course.dto.request.CourseEdit;
 import com.hana.sugang.api.course.dto.request.CourseSearch;
 import com.hana.sugang.api.course.dto.response.CourseResponse;
 import com.hana.sugang.api.course.repository.CourseRepository;
@@ -137,6 +139,111 @@ class CourseServiceTest {
         assertThat(after).isEqualTo(before+1);
 
     }
+    
+    
+    @Test
+    @DisplayName("강의 수정 성공케이스")
+    void editCourse() {
+        //given
+        Course savedCourse = courseRepository.save(createCourse());
+        CourseEdit courseEdit = createCourseEdit();
+
+        //when
+        //"테스트수정강의","설명입니다.수정.",33, courseType,2
+        courseService.editCourse(savedCourse.getId(), courseEdit);
+
+        //then
+        Course course = courseRepository.findById(savedCourse.getId()).orElseThrow(CourseNotFoundException::new);
+
+        assertThat(course.getTitle()).isEqualTo("테스트수정강의");
+        assertThat(course.getDescription()).isEqualTo("설명입니다.수정.");
+        assertThat(course.getMaxCount()).isEqualTo(33);
+        assertThat(course.getCourseType()).isEqualTo(CourseType.CC);
+        assertThat(course.getScore()).isEqualTo(2);
+    }
+
+
+    @Test
+    @DisplayName("강의 수정- 제목이 공백이면 제목을 제외하고 수정된다.")
+    void editCourseWithNoTitle() {
+        //given
+        Course savedCourse = courseRepository.save(createCourse());
+        CourseEdit courseEdit = createCourseEditNoTitle();
+
+        //when
+        courseService.editCourse(savedCourse.getId(), courseEdit);
+
+        //then
+        Course course = courseRepository.findById(savedCourse.getId()).orElseThrow(CourseNotFoundException::new);
+
+        assertThat(course.getTitle()).isEqualTo("테스트등록강의");
+        assertThat(course.getDescription()).isEqualTo("설명입니다.수정.");
+        assertThat(course.getMaxCount()).isEqualTo(33);
+        assertThat(course.getCourseType()).isEqualTo(CourseType.CC);
+        assertThat(course.getScore()).isEqualTo(2);
+    }
+
+
+    @Test
+    @DisplayName("강의 삭제 성공케이스")
+    void deleteCourse() {
+        //given
+        Course savedCourse = courseRepository.save(createCourse());
+        long before = courseRepository.count();
+
+        //when
+        courseService.deleteCourse(savedCourse.getId());
+
+        //then
+        long after = courseRepository.count();
+        assertThat(after).isEqualTo(before-1);
+        em.clear();
+    }
+    
+    @Test
+    @DisplayName("강의 삭제시 수강신청한 학생이 있는경우")
+    void deleteCourseWithApplyStudent() {
+        //given
+        Course initCourse = courseRepository.save(createCourse());
+        Member initMember = memberRepository.save(createMember());
+
+        initCourse.addCurrentCount();
+        initMember.addCurrentScore(initCourse.getScore());
+        Course savedCourse = courseRepository.save(initCourse);
+        Member savedMember = memberRepository.save(initMember);
+        MemberCourse memberCourse = MemberCourse.of(savedCourse, savedMember);
+        memberCourseRepository.save(memberCourse);
+
+        long beforeMC = memberCourseRepository.count();
+        long beforeCourseCount = courseRepository.count();
+        long beforeMemberCount = memberRepository.count();
+
+
+        //when
+        System.out.println("==여기==");
+        System.out.println(savedCourse.toString());
+        System.out.println(savedMember.toString());
+        System.out.println("==여기==");
+
+        courseService.deleteCourse(savedCourse.getId());
+        long afterMC = memberCourseRepository.count();
+
+        long afterCourseCount = courseRepository.count();
+        System.out.println("afterCourseCount = " + afterCourseCount);
+        long afterMemberCount = memberRepository.count();
+
+        System.out.println("==여기2==");
+        System.out.println(savedCourse.toString());
+        System.out.println(savedMember.toString());
+        System.out.println("afterMC-beforeMC = " + (afterMC-beforeMC));
+        System.out.println("afterCourseCount-beforeCourseCount = " + (afterCourseCount-beforeCourseCount));
+        System.out.println("afterMemberCount-beforeMemberCount = " + (afterMemberCount-beforeMemberCount));
+        System.out.println("==여기2==");
+        
+        
+    }
+
+
 
     @Test
     @DisplayName("수강신청 성공케이스")
@@ -265,6 +372,14 @@ class CourseServiceTest {
 
     private CourseCreate createCourseCreate() {
         return CourseCreate.of("ZZZZ01","테스트등록강의","설명입니다.",30,CourseType.CC,3);
+    }
+
+    private CourseEdit createCourseEdit() {
+        return CourseEdit.of("테스트수정강의","설명입니다.수정.",33, CourseType.CC,2);
+    }
+
+    private CourseEdit createCourseEditNoTitle() {
+        return CourseEdit.of(null,"설명입니다.수정.",33, CourseType.CC,2);
     }
 
 


### PR DESCRIPTION
강의도메인에 한해서 restAPI를 훨씬 다채롭게 만들었고
이에따른 테스트코드 및 성능최적화도 진행하였다.


아직 멤버도메인에 대해선 별다른 처리가 되어있지 않아서
이슈를 닫지는 않는다.

좀 더 메인 프로세스인 동시성이슈를 더 효율적으로 제어하기,
restAPI문서화, 시큐리티설정을 테스트코드에 추가한 후
한번 더 복습을 겸해서 적용하기 위해
멤버도메인 처리는 조금 더 후에 진행하기로 한다.