### PR TITLE
#36 Redis 성능최적화

### DIFF
--- a/src/main/java/com/hana/sugang/api/course/dto/request/CourseApply.java
+++ b/src/main/java/com/hana/sugang/api/course/dto/request/CourseApply.java
@@ -6,11 +6,16 @@ package com.hana.sugang.api.course.dto.request;
 public record CourseApply(
         Long courseId, // 강의Id
         String code, // 강의코드
+        Integer maxCount, // 강의정원
         Long memberId, //회원 Id
         String username //회원코드
 ) {
 
     public static CourseApply of(Long courseId, String username) {
-        return new CourseApply(courseId,null,null,username);
+        return new CourseApply(courseId,null, null,null,username);
+    }
+
+    public static CourseApply of(Long courseId, String code, Integer maxCount, String username) {
+        return new CourseApply(courseId,code, maxCount,null,username);
     }
 }

--- a/src/main/java/com/hana/sugang/api/course/service/Impl/CourseRDBService.java
+++ b/src/main/java/com/hana/sugang/api/course/service/Impl/CourseRDBService.java
@@ -74,7 +74,6 @@ public class CourseRDBService implements CourseService {
     public String applyCourse(CourseApply requestDto) {
         Course course = courseRepository.findBYIdWithQuery(requestDto.courseId()).orElseThrow(CourseNotFoundException::new);
         Member member = memberRepository.findBYUsernameWithQuery(requestDto.username()).orElseThrow(MemberNotFoundException::new);
-
         // 학생이 신청가능학점을 초과해서 신청하는경우
         if (member.isMaxScore(course.getScore())) {
             throw new MaxCountException("신청할 수 있는 학점을 초과했습니다.");
@@ -84,7 +83,6 @@ public class CourseRDBService implements CourseService {
         if (course.isFulled()) {
             throw new MaxCountException("수강인원이 가득 찼습니다.");
         }
-
         MemberCourse memberCourse = MemberCourse.of(course, member);
         memberCourseRepository.save(memberCourse);
 

--- a/src/test/java/com/hana/sugang/api/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/hana/sugang/api/course/controller/CourseControllerTest.java
@@ -476,7 +476,8 @@ class CourseControllerTest {
         Course savedCourse = courseRepository.save(CourseCreate.toEntity(requestDto));
         Member savedMember = memberRepository.save(createMember());
 
-        CourseApply courseApply = CourseApply.of(savedCourse.getId(), savedMember.getUsername());
+        CourseApply courseApply = CourseApply.of(savedCourse.getId(),savedCourse.getCode(),savedCourse.getMaxCount(), savedMember.getUsername());
+
 
         String json = objectMapper.writeValueAsString(courseApply);
 
@@ -512,7 +513,8 @@ class CourseControllerTest {
         
         Member savedMember = memberRepository.save(createMember());
 
-        CourseApply courseApply = CourseApply.of(savedCourse.getId(), savedMember.getUsername());
+
+        CourseApply courseApply = CourseApply.of(savedCourse.getId(),savedCourse.getCode(),savedCourse.getMaxCount(), savedMember.getUsername());
 
 
         String json = objectMapper.writeValueAsString(courseApply);
@@ -539,7 +541,7 @@ class CourseControllerTest {
         Member savedMember = memberRepository.save(createMember());
         savedMember.MaxCurrentScoreFORTEST();
 
-        CourseApply courseApply = CourseApply.of(savedCourse.getId(), savedMember.getUsername());
+        CourseApply courseApply = CourseApply.of(savedCourse.getId(),savedCourse.getCode(),savedCourse.getMaxCount(), savedMember.getUsername());
 
 
         String json = objectMapper.writeValueAsString(courseApply);

--- a/src/test/java/com/hana/sugang/api/course/service/Impl/CourseRDBServiceTest.java
+++ b/src/test/java/com/hana/sugang/api/course/service/Impl/CourseRDBServiceTest.java
@@ -326,9 +326,9 @@ class CourseRDBServiceTest {
      * mutilThread환경 테스트
      */
     @Test
-    @DisplayName("동시에 100개의 요청이 한개의 강의에 요청을 보내는 경우")
-    void current100request() throws Exception {
-        int threadCount = 100;
+    @DisplayName("동시에 500개의 요청이 한개의 강의에 요청을 보내는 경우")
+    void current500request() throws Exception {
+        int threadCount = 500;
         // 고정된 쓰레드풀을 생성
         ExecutorService executorService = Executors.newFixedThreadPool(32);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -346,9 +346,7 @@ class CourseRDBServiceTest {
                 }
             });
         }
-
         latch.await();
-
         //then
         Course findCourse = courseRepository.findById(savedCourse.getId()).orElseThrow(CourseNotFoundException::new);
         // (현재 수강신청 인원수).isEqualTo(최대 수강가능 인원수)


### PR DESCRIPTION
요청객체값을 변경하여
redis코드는 완전히 디스크와 분리하여 실행되게 변경하였다.
이로인해 테스트코드 전반적으로 요청객체를 변경하는 작업이 들어가서, 커밋단위가 커졌다.

또한 redisService 테스트코드에 어떤 이유였는지
테스트메소드가 충분하지 않았는데 이를 RDB서비스와 동일하게 내용을 더 풍부하게 채웠다.


-- commit메세지와 동일